### PR TITLE
Fix candid dependency and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-candid = { version = "0.10", features = ["candid_method"] }
+candid = "0.10.14"
 ic-cdk = "0.9"
 ic-cdk-macros = "0.9"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -136,3 +136,33 @@ Replace lib/dummyData.ts with real ICP canister calls when ready.
 
 
 Each page/component should have minimal working TSX, Tailwind classes, and placeholder text so the site builds successfully on first run.
+
+## Build and Deployment
+
+1. Clone the repository and enter the project root:
+
+   ```bash
+   git clone https://github.com/SpecSci/DeSci.git
+   cd DeSci
+   ```
+
+2. Build the Rust canister:
+
+   ```bash
+   cargo build --release
+   ```
+
+3. Install and build the frontend from the `spectranet` folder:
+
+   ```bash
+   cd spectranet
+   npm install
+   npm run build
+   ```
+
+4. Deploy the canisters using DFX:
+
+   ```bash
+   dfx deploy
+   ```
+


### PR DESCRIPTION
## Summary
- update `candid` dependency to a released version
- document build steps for backend and frontend

## Testing
- `cargo build --release` *(fails: failed to download from `https://index.crates.io/config.json`)*