### PR TITLE
Fix build instructions and dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Rust
+/target
+**/*.wasm
+
+# Node
+spectranet/node_modules/
+spectranet/.next/
+
+# Misc
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-candid = "0.8"
-ic-cdk = "0.9"
-ic-cdk-macros = "0.9"
+candid = "0.10"
+ic-cdk = "0.17"
+ic-cdk-macros = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -146,13 +146,21 @@ Each page/component should have minimal working TSX, Tailwind classes, and place
    cd DeSci
    ```
 
-2. Build the Rust canister:
+2. Install the recommended dfx version and build the Rust canister:
+
+   ```bash
+   dfxvm install 0.18.0
+   dfxvm default 0.18.0
+   ```
+
+   Then build the canister:
 
    ```bash
    cargo build --release
    ```
 
-3. Install and build the frontend from the `spectranet` folder:
+3. Install and build the frontend from the `spectranet` folder (there is no
+   `frontend` directory in this repo):
 
    ```bash
    cd spectranet


### PR DESCRIPTION
## Summary
- align dependencies with recent `ic-cdk`
- document installing the correct dfx version
- clarify frontend folder name
- add project `.gitignore`

## Testing
- `cargo build --release` *(fails: failed to download crates)*
