### PR TITLE
Fix build paths and update imports

### DIFF
--- a/spectranet/app/layout.tsx
+++ b/spectranet/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css'
+import '../styles/globals.css'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import Nav from '../components/Nav'
 import Footer from '../components/Footer'

--- a/spectranet/next.config.js
+++ b/spectranet/next.config.js
@@ -1,5 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: { appDir: true }
-}
+const nextConfig = {}
+
 module.exports = nextConfig

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 use ic_cdk::api::{caller, time};
 use ic_cdk::storage;
 use ic_cdk_macros::{init, pre_upgrade, post_upgrade, query, update};
-use ic_cdk::export::{candid::{CandidType, Deserialize}, Principal};
+use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};


### PR DESCRIPTION
## Summary
- point layout.tsx to the global stylesheet
- drop unused experimental option from next.config.js
- fix outdated ic-cdk import in Rust canister

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*
- `npm install` *(fails: network unreachable)*