### PR TITLE
Fix dashboard stats type mismatch

### DIFF
--- a/spectranet/app/dashboard/page.tsx
+++ b/spectranet/app/dashboard/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 import StatPanel from '../../components/StatPanel'
-import { useDashboardStats } from '../../lib/dummyData'
+import { useDashboardStats, type Stats } from '../../lib/dummyData'
 
 export default function DashboardPage() {
-  const stats = useDashboardStats()
+  const stats: Stats = useDashboardStats()
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Dashboard</h1>

--- a/spectranet/components/StatPanel.tsx
+++ b/spectranet/components/StatPanel.tsx
@@ -1,8 +1,4 @@
-interface Stats {
-  uploads: number
-  royalties: number
-  reputation: number
-}
+import type { Stats } from '../lib/dummyData'
 
 export default function StatPanel({ stats }: { stats: Stats }) {
   return (

--- a/spectranet/lib/dummyData.ts
+++ b/spectranet/lib/dummyData.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 
-interface Spectrum { id: number; name: string; points: { wavelength: number; intensity: number }[] }
+interface Spectrum {
+  id: number
+  name: string
+  points: { wavelength: number; intensity: number }[]
+}
 
 const spectra: Spectrum[] = Array.from({ length: 3 }, (_, i) => ({
   id: i + 1,
@@ -8,13 +12,22 @@ const spectra: Spectrum[] = Array.from({ length: 3 }, (_, i) => ({
   points: Array.from({ length: 10 }, (_, j) => ({ wavelength: j, intensity: Math.random() * 100 })),
 }))
 
+export interface Stats {
+  uploads: number
+  royalties: number
+  reputation: number
+}
+
 export function useDummySpectra() {
   const { data } = useQuery(['spectra'], () => new Promise<Spectrum[]>((res) => setTimeout(() => res(spectra), 500)))
   return data || spectra
 }
 
-export function useDashboardStats() {
-  const { data } = useQuery(['stats'], () => new Promise<{ uploads: number; royalties: number; reputation: number }>((res) =>
-    setTimeout(() => res({ uploads: 5, royalties: 12, reputation: 3 }), 500)))
+export function useDashboardStats(): Stats {
+  const { data } = useQuery<Stats>(['stats'], () =>
+    new Promise<Stats>((res) =>
+      setTimeout(() => res({ uploads: 5, royalties: 12, reputation: 3 }), 500)
+    )
+  )
   return data || { uploads: 0, royalties: 0, reputation: 0 }
 }


### PR DESCRIPTION
## Summary
- define `Stats` interface in dummy data hook
- fix `useDashboardStats` return type
- update `StatPanel` to import `Stats`
- type annotate stats on dashboard page

## Testing
- `git status --short`