### PR TITLE
Fix untyped spectra function

### DIFF
--- a/spectranet/lib/dummyData.ts
+++ b/spectranet/lib/dummyData.ts
@@ -18,8 +18,10 @@ export interface Stats {
   reputation: number
 }
 
-export function useDummySpectra() {
-  const { data } = useQuery(['spectra'], () => new Promise<Spectrum[]>((res) => setTimeout(() => res(spectra), 500)))
+export function useDummySpectra(): Spectrum[] {
+  const { data } = useQuery<Spectrum[]>(['spectra'], () =>
+    new Promise<Spectrum[]>((res) => setTimeout(() => res(spectra), 500))
+  )
   return data || spectra
 }
 


### PR DESCRIPTION
## Summary
- define explicit return type for dummy spectra data

## Testing
- `npx --yes tsc -p spectranet` *(fails: Cannot find type definition file for 'node')*