### PR TITLE
Fix framer-motion types

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,13 @@ Each page/component should have minimal working TSX, Tailwind classes, and place
 ## Viewing Logs
 
 Avoid using `tail` to inspect logs because it may hang. Use `less` or `cat` instead.
+
+## Avoiding commands that hang
+
+Some commands may freeze when they require network access or wait indefinitely. If a command hangs,
+abort it with `Ctrl+C` and list it here so it isn't run again.
+
+### Known hanging commands
+
+- `npm install` in the `spectranet` folder (attempted during build; it stalled due to network
+  restrictions).

--- a/spectranet/global.d.ts
+++ b/spectranet/global.d.ts
@@ -1,0 +1,7 @@
+import 'framer-motion'
+
+declare module 'framer-motion' {
+  interface MotionProps {
+    className?: string
+  }
+}

--- a/spectranet/tsconfig.json
+++ b/spectranet/tsconfig.json
@@ -17,6 +17,6 @@
     "types": ["node"],
     "baseUrl": "."
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add module augmentation for framer-motion MotionProps so `className` works
- reference the new declaration in tsconfig
- document commands that may hang

## Testing
- `Ctrl+C` after `npm install` (hung due to network)
