### PR TITLE
Fix tsconfig types and document network issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Each page/component should have minimal working TSX, Tailwind classes, and place
    ```bash
    cargo build --release
    ```
+   If `cargo build` fails to connect to crates.io due to network issues,
+   cancel with `Ctrl+C` and retry when a connection is available.
 
 3. Install and build the frontend from the `spectranet` folder (there is no
    `frontend` directory in this repo):
@@ -183,3 +185,14 @@ Each page/component should have minimal working TSX, Tailwind classes, and place
 ## Viewing Logs
 
 Avoid using `tail` to inspect logs because it may hang. Use `less` or `cat` instead.
+
+### Known Issues
+
+Running `npm install` inside the `spectranet` directory hung during testing
+when network access was slow. If this occurs, cancel the command with `Ctrl+C`
+and retry with the `--silent` flag or ensure the network connection is stable.
+
+Running `cargo build` may also fail to download crates because of temporary
+network problems. TypeScript checks (`npx tsc --noEmit`) require `@types/node`
+and `@types/react` to be installed; if package installation fails, these checks
+will report missing type definition errors.

--- a/spectranet/package.json
+++ b/spectranet/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.61",
+    "@types/react-dom": "^18.2.17"
   }
 }

--- a/spectranet/tsconfig.json
+++ b/spectranet/tsconfig.json
@@ -14,9 +14,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
-    "baseUrl": "."
+    "types": ["node", "react"],
+    "baseUrl": ".",
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add React type dependencies for the frontend
- configure `tsconfig.json` for React and Next.js
- document hangs with `npm install` and `cargo build`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*
- `cargo build --release` *(fails: Could not connect to server)*